### PR TITLE
Use `vm.runInThisContext` instead of eval

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -31,7 +31,9 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var defaultReviver, nodeTypeString, nodes, parse, syntaxErrorMessage;
+var defaultReviver, nodeTypeString, nodes, parse, parseStringLiteral, runInThisContext, syntaxErrorMessage;
+
+runInThisContext = require('vm').runInThisContext;
 
 nodes = require('coffee-script').nodes;
 
@@ -53,6 +55,10 @@ syntaxErrorMessage = function(csNode, msg) {
     column = columnIdx + 1;
   }
   return "Syntax error on line " + line + ", column " + column + ": " + msg;
+};
+
+parseStringLiteral = function(literal) {
+  return runInThisContext(literal);
 };
 
 parse = function(source, reviver) {
@@ -83,7 +89,7 @@ parse = function(source, reviver) {
       value = node.value;
       try {
         if (value[0] === "'") {
-          return eval(value);
+          return parseStringLiteral(value);
         } else {
           return JSON.parse(value);
         }
@@ -172,7 +178,7 @@ parse = function(source, reviver) {
         value = csNode.base.value;
         switch (value[0]) {
           case '\'':
-            return eval(value);
+            return parseStringLiteral(value);
           case '"':
             return JSON.parse(value);
           default:


### PR DESCRIPTION
Fixes #17

While this gets rid of `eval` in node and in "mixed" environments like node-webkit or Atom Shell apps, it still resolves to eval when using browserify.

For a solution that is compatible with CSP policies we'd need actual parsing of the literals (wish coffee-script would do it).

See:
* https://github.com/substack/vm-browserify/blob/bfd7c5f59edec856dc7efe0b77a4f6b2fa20f226/index.js#L105