### PR TITLE
Be explicit about registry for publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "coffee-script": "^1.8.0"
   },
   "publishConfig": {
+    "registry": "https://registry.npmjs.org",
     "license": {
       "exclude": [
         "lib",


### PR DESCRIPTION
Prevents accidentally publishing to the wrong registry.